### PR TITLE
Fix bugs in TorpedoStore.java

### DIFF
--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -43,7 +43,7 @@ public class TorpedoStore {
 
     if (r >= FAILURE_RATE) {
       // successful firing
-      this.torpedoCount =- numberOfTorpedos;
+      this.torpedoCount -= numberOfTorpedos;
       success = true;
     } else {
       // simulated failure

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -33,7 +33,7 @@ public class TorpedoStore {
 
   public boolean fire(int numberOfTorpedos){
     if(numberOfTorpedos < 1 || numberOfTorpedos > this.torpedoCount){
-      new IllegalArgumentException("numberOfTorpedos");
+      throw new IllegalArgumentException("numberOfTorpedos");
     }
 
     boolean success = false;

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -12,13 +12,12 @@ public class TorpedoStore {
   // rate of failing to fire torpedos [0.0, 1.0]
   private double FAILURE_RATE = 0.0; //NOSONAR
 
-  Random generator;
+  static Random generator=new Random();
 
   private int torpedoCount = 0;
 
   public TorpedoStore(int numberOfTorpedos){
     this.torpedoCount = numberOfTorpedos;
-    generator=new Random();
 
     // update failure rate if it was specified in an environment variable
     String failureEnv = System.getenv("IVT_RATE");

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -12,10 +12,13 @@ public class TorpedoStore {
   // rate of failing to fire torpedos [0.0, 1.0]
   private double FAILURE_RATE = 0.0; //NOSONAR
 
+  Random generator;
+
   private int torpedoCount = 0;
 
   public TorpedoStore(int numberOfTorpedos){
     this.torpedoCount = numberOfTorpedos;
+    generator=new Random();
 
     // update failure rate if it was specified in an environment variable
     String failureEnv = System.getenv("IVT_RATE");
@@ -36,7 +39,6 @@ public class TorpedoStore {
     boolean success = false;
 
     // simulate random overheating of the launcher bay which prevents firing
-    Random generator = new Random();
     double r = generator.nextDouble();
 
     if (r >= FAILURE_RATE) {


### PR DESCRIPTION
Sonarlint found two major and one minor vulnarilibity in TorpedoStore.java.
- random generator must be inicialialized in constructor for guaranteed uniform distribution
-Exception was created but not throwed wich made the code vulnerable against out-of-range input values.
- when decreasing torpedocount =- was used instead of -= which left the model in an invalid state.